### PR TITLE
feat(TerminalPane): add visibility observer to handle terminal resizi…

### DIFF
--- a/apps/desktop/src/components/TerminalPane.tsx
+++ b/apps/desktop/src/components/TerminalPane.tsx
@@ -226,6 +226,34 @@ export function TerminalPane({ id, cwd }: Props) {
     });
     resizeObserver.observe(containerRef.current);
 
+    let wasVisible = false;
+    let visibilityRaf = 0;
+    const visibilityObserver = new IntersectionObserver((entries) => {
+      if (!alive) return;
+      for (const entry of entries) {
+        const nowVisible = entry.isIntersecting && entry.intersectionRatio > 0;
+        if (nowVisible && !wasVisible) {
+          if (visibilityRaf !== 0) cancelAnimationFrame(visibilityRaf);
+          visibilityRaf = requestAnimationFrame(() => {
+            visibilityRaf = 0;
+            if (!alive) return;
+            try {
+              fit.fit();
+              term.refresh(0, term.rows - 1);
+              const { cols: c, rows: r } = term;
+              void ipc.terminalResize(id, c, r).catch((err: unknown) => {
+                console.warn('terminalResize failed', err);
+              });
+            } catch {
+              // empty
+            }
+          });
+        }
+        wasVisible = nowVisible;
+      }
+    });
+    visibilityObserver.observe(containerRef.current);
+
     return () => {
       alive = false;
       termRef.current = null;
@@ -235,7 +263,12 @@ export function TerminalPane({ id, cwd }: Props) {
         cancelAnimationFrame(resizeRaf);
         resizeRaf = 0;
       }
+      if (visibilityRaf !== 0) {
+        cancelAnimationFrame(visibilityRaf);
+        visibilityRaf = 0;
+      }
       resizeObserver.disconnect();
+      visibilityObserver.disconnect();
       void ipc.terminalDestroy(id).catch(() => undefined);
       term.dispose();
     };


### PR DESCRIPTION
…ng on visibility change

Implemented an IntersectionObserver to monitor the visibility of the TerminalPane component. This enhancement ensures that the terminal is resized and refreshed only when it becomes visible, improving performance and resource management. Cleaned up the observer on component unmount to prevent memory leaks.

## Summary

<!-- What does this PR do? Link issues with `Closes #123`. -->

## Changes

- [ ] <!-- bullet list of meaningful changes -->

## Verification

- [ ] `pnpm typecheck`
- [ ] `pnpm lint`
- [ ] `pnpm format:check`
- [ ] `cargo fmt --check` (src-tauri)
- [ ] `cargo clippy -- -D warnings` (src-tauri)
- [ ] Manually exercised the change (describe)

## Screenshots / demo

<!-- For UI changes. -->

## Notes for reviewers

<!-- Call out anything non-obvious. -->

---

<!--
PR title must follow Conventional Commits: feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert
Example: "feat(scanner): Detect Go modules via go.mod"

Auto-merge: If you have push access, enable "Auto-merge" (squash) after CI passes.
-->
