### PR TITLE
feat: add tab restoration functionality to GroupTabStrip

### DIFF
--- a/apps/desktop/src/components/layout/GroupTabStrip.tsx
+++ b/apps/desktop/src/components/layout/GroupTabStrip.tsx
@@ -6,12 +6,25 @@
  * which overlays each group's body during an active drag.
  */
 
-import { Plus, RotateCcw } from 'lucide-react';
+import { useCallback, useRef, useState } from 'react';
+import { BookOpen, FileText, Plus, RotateCcw, Undo2 } from 'lucide-react';
+
+import { FileContextMenu, type FileContextMenuEntry } from '@/components/ui/FileContextMenu';
 
 import { TabEndSlot } from './TabEndSlot';
 import { TabStripAction } from './TabStripAction';
 import { TabStripItem } from './TabStripItem';
-import type { GroupNode, Tab } from './layoutModel';
+import type { GroupNode, Tab, TabKind } from './layoutModel';
+
+const RESTORE_LABEL: Record<'docs' | 'notes', string> = {
+  docs: 'Docs',
+  notes: 'Notes',
+};
+
+const RESTORE_ICON: Record<'docs' | 'notes', typeof BookOpen> = {
+  docs: BookOpen,
+  notes: FileText,
+};
 
 interface Props {
   group: GroupNode;
@@ -27,6 +40,10 @@ interface Props {
    *  *root* group renders this affordance; passing `null` for the
    *  non-root groups suppresses the button. */
   onReset: (() => void) | null;
+  /** Tab kinds the user has explicitly closed (docs / notes). Only the
+   *  root group renders the restore affordance, mirroring `onReset`. */
+  closedKinds: TabKind[];
+  onRestore: ((kind: TabKind) => void) | null;
   /** This group's pane currently owns keyboard focus. Tabs in a
    *  focused pane render with a brighter accent fill so the user
    *  can locate "where my next keystroke goes" at a glance even
@@ -43,6 +60,8 @@ export function GroupTabStrip({
   onRename,
   onAddTerminal,
   onReset,
+  closedKinds,
+  onRestore,
   groupFocused,
 }: Props) {
   const visibleIds = group.tabs.filter((id) => {
@@ -50,6 +69,32 @@ export function GroupTabStrip({
     if (!t) return false;
     if (t.kind === 'docs' && !includeDocs) return false;
     return true;
+  });
+
+  const restoreBtnRef = useRef<HTMLDivElement | null>(null);
+  const [restoreMenuPos, setRestoreMenuPos] = useState<{ x: number; y: number } | null>(null);
+  const restorableKinds = closedKinds.filter((k): k is 'docs' | 'notes' => {
+    if (k !== 'docs' && k !== 'notes') return false;
+    if (k === 'docs' && !includeDocs) return false;
+    return true;
+  });
+  const showRestore = onRestore !== null && restorableKinds.length > 0;
+
+  const openRestoreMenu = useCallback(() => {
+    const el = restoreBtnRef.current;
+    if (!el) return;
+    const rect = el.getBoundingClientRect();
+    setRestoreMenuPos({ x: rect.left, y: rect.bottom + 4 });
+  }, []);
+
+  const restoreMenuItems: FileContextMenuEntry[] = restorableKinds.map((kind) => {
+    const Icon = RESTORE_ICON[kind];
+    return {
+      id: `restore-${kind}`,
+      label: `Restore ${RESTORE_LABEL[kind]}`,
+      icon: <Icon className="h-3.5 w-3.5" />,
+      onClick: () => onRestore?.(kind),
+    };
   });
 
   return (
@@ -92,6 +137,16 @@ export function GroupTabStrip({
           title="New terminal in this pane"
           onClick={onAddTerminal}
         />
+        {showRestore && (
+          <div ref={restoreBtnRef}>
+            <TabStripAction
+              icon={<Undo2 className="h-3 w-3" />}
+              label="Restore Tab"
+              title="Restore a closed tab"
+              onClick={openRestoreMenu}
+            />
+          </div>
+        )}
         {onReset && (
           <TabStripAction
             icon={<RotateCcw className="h-3 w-3" />}
@@ -101,6 +156,14 @@ export function GroupTabStrip({
           />
         )}
       </div>
+      {restoreMenuPos && (
+        <FileContextMenu
+          x={restoreMenuPos.x}
+          y={restoreMenuPos.y}
+          items={restoreMenuItems}
+          onClose={() => setRestoreMenuPos(null)}
+        />
+      )}
     </div>
   );
 }

--- a/apps/desktop/src/components/layout/ServiceLayout.tsx
+++ b/apps/desktop/src/components/layout/ServiceLayout.tsx
@@ -31,6 +31,7 @@ export function ServiceLayout({ layout, onSlotRef, onAddTerminalToEmpty }: Props
     activate,
     addTerminal,
     closeTab,
+    restoreTab,
     renameTab,
     moveTab,
     splitTab,
@@ -99,6 +100,8 @@ export function ServiceLayout({ layout, onSlotRef, onAddTerminalToEmpty }: Props
             onAddTerminal={() => addTerminal(node.id)}
             onAddTerminalToEmpty={() => onAddTerminalToEmpty(node.id)}
             onReset={isRoot ? reset : null}
+            closedKinds={state.closedKinds}
+            onRestore={isRoot ? restoreTab : null}
             onSlotRef={onSlotRef}
             dragActive={drag !== null}
             focused={focusedGroupId === node.id}
@@ -118,6 +121,7 @@ export function ServiceLayout({ layout, onSlotRef, onAddTerminalToEmpty }: Props
       activate,
       addTerminal,
       closeTab,
+      restoreTab,
       drag,
       focusedGroupId,
       onAddTerminalToEmpty,
@@ -125,6 +129,7 @@ export function ServiceLayout({ layout, onSlotRef, onAddTerminalToEmpty }: Props
       renameTab,
       reset,
       resizeSplit,
+      state.closedKinds,
       state.includeDocs,
       state.tabs,
     ],

--- a/apps/desktop/src/components/layout/TabStripItem.tsx
+++ b/apps/desktop/src/components/layout/TabStripItem.tsx
@@ -33,7 +33,11 @@ export function TabStripItem({
   onClose,
   onRename,
 }: TabStripItemProps) {
-  const closeable = tab.kind === 'terminal' || (tab.kind === 'logs' && Boolean(tab.commandName));
+  const closeable =
+    tab.kind === 'terminal' ||
+    (tab.kind === 'logs' && Boolean(tab.commandName)) ||
+    tab.kind === 'docs' ||
+    tab.kind === 'notes';
   const renameable = tab.kind === 'terminal';
   const {
     attributes: dragAttrs,

--- a/apps/desktop/src/components/layout/layoutDefaults.ts
+++ b/apps/desktop/src/components/layout/layoutDefaults.ts
@@ -27,5 +27,6 @@ export function defaultLayoutState(commandNames: string[] = []): LayoutState {
     nextTermIdx: 2,
     includeDocs: false,
     knownLogCommands: commands,
+    closedKinds: [],
   };
 }

--- a/apps/desktop/src/components/layout/layoutModel.ts
+++ b/apps/desktop/src/components/layout/layoutModel.ts
@@ -3,12 +3,23 @@ import {
   collapseEmptyGroups,
   findGroup,
   insertTabIntoGroup,
+  listGroups,
   removeTabFromTree,
   splitTreeAroundGroup,
   updateNode,
 } from './layoutTree';
 import { openCommandLogTab, syncCommandLogTabs } from './commandLogLayout';
-import type { LayoutAction, LayoutState, Tab } from './layoutTypes';
+import { nextLogInsertIndex } from './layoutLogTabs';
+import type { LayoutAction, LayoutState, Tab, TabKind } from './layoutTypes';
+
+const RESTORABLE_TAB_DEFAULTS: Record<'docs' | 'notes', { id: string; title: string }> = {
+  docs: { id: 'docs', title: 'Docs' },
+  notes: { id: 'notes', title: 'Notes' },
+};
+
+function isRestorableKind(kind: TabKind): kind is 'docs' | 'notes' {
+  return kind === 'docs' || kind === 'notes';
+}
 
 export { defaultLayoutState } from './layoutDefaults';
 export { activeCommandLogName, commandNameForLogTab, findCommandLogTabId } from './layoutLogTabs';
@@ -91,14 +102,45 @@ export function layoutReducer(state: LayoutState, action: LayoutAction): LayoutS
 
     case 'close-tab': {
       const tab = state.tabs[action.tabId];
-      if (!tab || (tab.kind !== 'terminal' && !(tab.kind === 'logs' && tab.commandName))) {
-        return state;
-      }
+      const isCloseable =
+        tab &&
+        (tab.kind === 'terminal' ||
+          (tab.kind === 'logs' && Boolean(tab.commandName)) ||
+          isRestorableKind(tab.kind));
+      if (!tab || !isCloseable) return state;
       const root1 = removeTabFromTree(state.root, action.tabId);
       const root2 = collapseEmptyGroups(root1);
       const { [action.tabId]: _removed, ...remainingTabs } = state.tabs;
       void _removed;
-      return { ...state, root: root2, tabs: remainingTabs };
+      const nextClosedKinds = isRestorableKind(tab.kind)
+        ? state.closedKinds.includes(tab.kind)
+          ? state.closedKinds
+          : [...state.closedKinds, tab.kind]
+        : state.closedKinds;
+      return { ...state, root: root2, tabs: remainingTabs, closedKinds: nextClosedKinds };
+    }
+
+    case 'restore-tab': {
+      if (!isRestorableKind(action.kind)) return state;
+      if (state.tabs[action.kind]) return state;
+      const defaults = RESTORABLE_TAB_DEFAULTS[action.kind];
+      const restored: Tab = { id: defaults.id, kind: action.kind, title: defaults.title };
+      const targetGroup = listGroups(state.root)[0];
+      if (!targetGroup) return state;
+      const insertIndex = nextLogInsertIndex(targetGroup, state.tabs);
+      const root = insertTabIntoGroup(
+        state.root,
+        targetGroup.id,
+        restored.id,
+        insertIndex,
+        /* activate */ false,
+      );
+      return {
+        ...state,
+        root,
+        tabs: { ...state.tabs, [restored.id]: restored },
+        closedKinds: state.closedKinds.filter((k) => k !== action.kind),
+      };
     }
 
     case 'move-tab': {

--- a/apps/desktop/src/components/layout/layoutPersistence.ts
+++ b/apps/desktop/src/components/layout/layoutPersistence.ts
@@ -53,6 +53,7 @@ export function loadLayout(serviceId: string, commandNames: string[] = []): Layo
     return {
       ...env.state,
       knownLogCommands: Array.isArray(env.state.knownLogCommands) ? env.state.knownLogCommands : [],
+      closedKinds: Array.isArray(env.state.closedKinds) ? env.state.closedKinds : [],
     };
   } catch {
     return defaultLayoutState(commandNames);

--- a/apps/desktop/src/components/layout/layoutTypes.ts
+++ b/apps/desktop/src/components/layout/layoutTypes.ts
@@ -31,6 +31,7 @@ export interface LayoutState {
   nextTermIdx: number;
   includeDocs: boolean;
   knownLogCommands: string[];
+  closedKinds: TabKind[];
 }
 
 export type LayoutAction =
@@ -55,4 +56,5 @@ export type LayoutAction =
     }
   | { type: 'resize-split'; splitId: string; sizes: [number, number] }
   | { type: 'set-include-docs'; includeDocs: boolean }
+  | { type: 'restore-tab'; kind: TabKind }
   | { type: 'reset'; commands?: string[] };

--- a/apps/desktop/src/components/layout/service-layout/GroupPane.tsx
+++ b/apps/desktop/src/components/layout/service-layout/GroupPane.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from 'react';
 import { GroupTabStrip } from '../GroupTabStrip';
 import { PaneDropZones } from '../PaneDropZones';
-import type { GroupNode, Tab } from '../layoutModel';
+import type { GroupNode, Tab, TabKind } from '../layoutModel';
 import { BodySlot } from './BodySlot';
 import { EmptyPaneState } from './EmptyPaneState';
 
@@ -15,6 +15,8 @@ interface GroupPaneProps {
   onAddTerminal: () => void;
   onAddTerminalToEmpty: () => void;
   onReset: (() => void) | null;
+  closedKinds: TabKind[];
+  onRestore: ((kind: TabKind) => void) | null;
   onSlotRef: (tabId: string, el: HTMLDivElement | null) => void;
   dragActive: boolean;
   focused: boolean;
@@ -30,6 +32,8 @@ export function GroupPane({
   onAddTerminal,
   onAddTerminalToEmpty,
   onReset,
+  closedKinds,
+  onRestore,
   onSlotRef,
   dragActive,
   focused,
@@ -57,6 +61,8 @@ export function GroupPane({
         onRename={onRename}
         onAddTerminal={onAddTerminal}
         onReset={onReset}
+        closedKinds={closedKinds}
+        onRestore={onRestore}
         groupFocused={focused}
       />
       <div className="relative flex min-h-0 flex-1">

--- a/apps/desktop/src/components/layout/useServiceLayout.ts
+++ b/apps/desktop/src/components/layout/useServiceLayout.ts
@@ -18,6 +18,7 @@ import {
   type LayoutAction,
   type LayoutState,
   type SplitEdge,
+  type TabKind,
 } from './layoutModel';
 import { clearLayout, loadLayout, saveLayout } from './layoutPersistence';
 
@@ -33,6 +34,7 @@ export interface UseServiceLayoutResult {
   // ---- Tab lifecycle ------------------------------------------------------
   addTerminal: (groupId?: string) => string;
   closeTab: (tabId: string) => void;
+  restoreTab: (kind: TabKind) => void;
   openCommandLog: (commandName: string) => void;
   renameTab: (tabId: string, title: string) => void;
   // ---- Drag/drop ----------------------------------------------------------
@@ -116,6 +118,7 @@ export function useServiceLayout(
   );
 
   const closeTab = useCallback((tabId: string) => send({ type: 'close-tab', tabId }), [send]);
+  const restoreTab = useCallback((kind: TabKind) => send({ type: 'restore-tab', kind }), [send]);
   const openCommandLog = useCallback(
     (commandName: string) => send({ type: 'open-command-log-tab', commandName }),
     [send],
@@ -173,6 +176,7 @@ export function useServiceLayout(
       activate,
       addTerminal,
       closeTab,
+      restoreTab,
       openCommandLog,
       renameTab,
       moveTab,
@@ -187,6 +191,7 @@ export function useServiceLayout(
       activate,
       addTerminal,
       closeTab,
+      restoreTab,
       openCommandLog,
       renameTab,
       moveTab,


### PR DESCRIPTION
- Implemented restore button and context menu for closed tabs (docs/notes) in GroupTabStrip.
- Updated layout state to track closed tab kinds.
- Enhanced layout reducer to handle closing and restoring tabs.
- Modified relevant components to support new restore functionality, including ServiceLayout and GroupPane.

This feature allows users to restore previously closed tabs, improving user experience and tab management.

## Summary

<!-- What does this PR do? Link issues with `Closes #123`. -->

## Changes

- [ ] <!-- bullet list of meaningful changes -->

## Verification

- [ ] `pnpm typecheck`
- [ ] `pnpm lint`
- [ ] `pnpm format:check`
- [ ] `cargo fmt --check` (src-tauri)
- [ ] `cargo clippy -- -D warnings` (src-tauri)
- [ ] Manually exercised the change (describe)

## Screenshots / demo

<!-- For UI changes. -->

## Notes for reviewers

<!-- Call out anything non-obvious. -->

---

<!--
PR title must follow Conventional Commits: feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert
Example: "feat(scanner): Detect Go modules via go.mod"

Auto-merge: If you have push access, enable "Auto-merge" (squash) after CI passes.
-->
