### PR TITLE
fix(windows): hide helper process console windows

### DIFF
--- a/crates/runhq-core/src/editors/launch.rs
+++ b/crates/runhq-core/src/editors/launch.rs
@@ -30,10 +30,14 @@ pub async fn open_in_editor(command: &str, path: &Path) -> AppResult<()> {
 
 async fn spawn_with_path(exe: PathBuf, path: &Path) -> AppResult<()> {
     let display = exe.display().to_string();
-    let mut child = tokio::process::Command::new(&exe)
-        .arg(path)
+    let mut cmd = tokio::process::Command::new(&exe);
+    cmd.arg(path)
         .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null());
+    // `code.cmd` / similar editor shims are console scripts; hide the
+    // brief cmd flash when opening a project from the dashboard.
+    crate::hide_console::tokio_command(&mut cmd);
+    let mut child = cmd
         .spawn()
         .map_err(|e| AppError::Other(format!("failed to launch '{display}': {e}")))?;
 

--- a/crates/runhq-core/src/git/runner.rs
+++ b/crates/runhq-core/src/git/runner.rs
@@ -80,6 +80,9 @@ fn configure_git_cmd(cmd: &mut Command, cwd: &Path) {
     for var in LEAKY_GIT_ENV {
         cmd.env_remove(var);
     }
+    // git.exe is a console-subsystem binary. Without CREATE_NO_WINDOW,
+    // the 15–30s git-status poller flashes a cmd window per project.
+    crate::hide_console::std_command(cmd);
 }
 
 /// Run `git` in `cwd`. Returns `(success, stdout, stderr)`.

--- a/crates/runhq-core/src/hide_console.rs
+++ b/crates/runhq-core/src/hide_console.rs
@@ -1,0 +1,67 @@
+//! Hide helper-process consoles on Windows.
+//!
+//! A windowed Tauri app that spawns a console-subsystem binary (`git.exe`,
+//! `npm.cmd`, `cmd.exe`, …) without `CREATE_NO_WINDOW` flashes a black
+//! terminal for the lifetime of that child. RunHQ polls `git status` on
+//! every project every few seconds and shells out to `npm outdated` /
+//! `cargo audit` during dependency scans, so the flash is constant, not
+//! a one-off.
+//!
+//! Apply this to **headless** helpers whose stdout/stderr we already
+//! pipe. Do **not** apply it to PTY-backed service shells — those need
+//! a console attached to ConPTY so `dotnet run` / `npm run dev` can
+//! stream into the in-app terminal.
+
+/// `CREATE_NO_WINDOW` — see
+/// <https://learn.microsoft.com/en-us/windows/win32/procthread/process-creation-flags>.
+#[cfg(windows)]
+const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+
+/// Suppress the console window of a [`std::process::Command`] helper.
+/// No-op on Unix.
+pub fn std_command(cmd: &mut std::process::Command) {
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+        cmd.creation_flags(CREATE_NO_WINDOW);
+    }
+    #[cfg(not(windows))]
+    {
+        let _ = cmd;
+    }
+}
+
+/// Suppress the console window of a [`tokio::process::Command`] helper.
+/// No-op on Unix.
+pub fn tokio_command(cmd: &mut tokio::process::Command) {
+    #[cfg(windows)]
+    {
+        cmd.creation_flags(CREATE_NO_WINDOW);
+    }
+    #[cfg(not(windows))]
+    {
+        let _ = cmd;
+    }
+}
+
+#[cfg(all(test, windows))]
+mod tests {
+    use super::*;
+    use std::process::{Command, Stdio};
+
+    #[test]
+    fn hidden_cmd_still_captures_stdout() {
+        let mut cmd = Command::new("cmd");
+        cmd.args(["/C", "echo hidden-ok"])
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+        std_command(&mut cmd);
+        let out = cmd.output().expect("cmd.exe should spawn");
+        assert!(out.status.success());
+        let stdout = String::from_utf8_lossy(&out.stdout);
+        assert!(
+            stdout.contains("hidden-ok"),
+            "CREATE_NO_WINDOW must not swallow piped stdout, got {stdout:?}"
+        );
+    }
+}

--- a/crates/runhq-core/src/lib.rs
+++ b/crates/runhq-core/src/lib.rs
@@ -29,6 +29,7 @@ pub mod editors;
 pub mod error;
 pub mod events;
 pub mod git;
+pub mod hide_console;
 pub mod license;
 pub mod logs;
 pub mod notes;

--- a/crates/runhq-core/src/license/runner.rs
+++ b/crates/runhq-core/src/license/runner.rs
@@ -18,17 +18,7 @@ pub(super) async fn run_timed(program: &str, args: &[&str], cwd: &Path) -> Optio
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::null())
         .kill_on_drop(true);
-    // Suppress the console window flash on Windows. Without this, a
-    // license scan would briefly pop a black `cmd.exe`-style window
-    // every time the user clicked Rescan — jarring inside a windowed
-    // Tauri shell. CREATE_NO_WINDOW = 0x08000000. `tokio::process::
-    // Command` exposes `creation_flags` directly on Windows, so we
-    // don't need the `std::os::windows::process::CommandExt` import
-    // (which clippy flags as unused under -D warnings).
-    #[cfg(windows)]
-    {
-        cmd.creation_flags(0x0800_0000);
-    }
+    crate::hide_console::tokio_command(&mut cmd);
 
     let child = match cmd.spawn() {
         Ok(c) => c,

--- a/crates/runhq-core/src/overview/checks/runner.rs
+++ b/crates/runhq-core/src/overview/checks/runner.rs
@@ -29,6 +29,10 @@ pub(super) async fn run_timed(
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::null())
         .kill_on_drop(true);
+    // npm.cmd / cargo.exe are console apps. The dashboard runs
+    // `npm outdated` / `cargo audit` in parallel per project; without
+    // CREATE_NO_WINDOW each one pops a black terminal.
+    crate::hide_console::tokio_command(&mut cmd);
 
     let child = match cmd.spawn() {
         Ok(c) => c,

--- a/crates/runhq-core/src/process/diagnostics.rs
+++ b/crates/runhq-core/src/process/diagnostics.rs
@@ -89,6 +89,7 @@ pub(super) async fn emit_launch_diagnostics(
                 .args(&probe_args)
                 .current_dir(&svc.cwd)
                 .stdin(Stdio::null());
+            crate::hide_console::tokio_command(&mut probe_cmd);
             let current = std::env::var("PATH").unwrap_or_default();
             probe_cmd.env("PATH", format!("{}:{}", path_extra.trim(), current));
             if let Ok(out) = probe_cmd.output().await {


### PR DESCRIPTION
## Summary
- Windows was flashing a black `cmd.exe` window on every `git status` poll (every 15-30s per project) and during `npm outdated` / `cargo audit` scans.
- License scans already passed `CREATE_NO_WINDOW`; git, overview, diagnostics, and editor-shim launches did not.
- Shared helper `hide_console` now applies that flag to headless helpers. PTY-backed service shells (`dotnet run` / `npm run dev`) are left alone so ConPTY still works.

## Test plan
- [ ] On Windows, open a workspace with several git repos and leave the dashboard open for a minute: no console windows should flash.
- [ ] Click Scan dependencies: `npm outdated` / `cargo audit` should not pop terminals.
- [ ] Start a service from the UI: in-app terminal still receives output.
- [ ] `cargo test -p runhq-core` and `cargo clippy -p runhq-core --all-targets -- -D warnings`

Made with [Cursor](https://cursor.com)